### PR TITLE
template support to basePath

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -18,7 +18,7 @@ module.exports = function (grunt) {
     // If we have a basePath, specify it
     if (this.data.options.basePath) {
       //var base = grunt.file.expandDirs(this.data.options.basePath);
-      var base = this.data.options.basePath;
+      var base = grunt.template.process(this.data.options.basePath);
       grunt.file.setBase(base);
     }
 


### PR DESCRIPTION
Adding grunt template support to basePath.
I'm not into grunt development, but this change works fine for me!
example usage: 
    manifest: {
      generate: {
        options: {
          basePath: "<%= meta.version %>/",
          ...
