### PR TITLE
Rename grunt-contrib-lib to grunt-lib-contrib

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-contrib-lib": "~0.3.0"
+    "grunt-lib-contrib": "~0.3.0"
   },
   "devDependencies": {
     "grunt": "~0.3.15",


### PR DESCRIPTION
https://github.com/gunta/grunt-contrib-manifest/issues/1

Sorry, forgot to rename in dependencies in package.json
It's ok now. You can try to install it from my repo: npm install https://github.com/tm-minty/grunt-contrib-manifest/archive/master.tar.gz

Thanks
