### PR TITLE
Warning about appcache getting fed standard cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ manifest: {
   generate: {
     options: {
       basePath: "../",
-      cache: ["js/app.js?rel=3230239039", "css/style?rel=43049"]
+      cache: ["js/app.js", "css/style.css"]
       network: ["http://*", "https://*"],
       fallback: ["/ /offline.html"],
       exclude: ["js/jquery.min.js"],
@@ -114,8 +114,8 @@ CACHE MANIFEST
 # Time: Mon Jan 01 2155 22:23:24 GMT+0900 (JST)
 
 CACHE:
-js/app.js?rel=3230239039
-css/style?rel=43049
+js/app.js
+css/style
 css/style.css
 js/zepto.min.js
 js/script.js
@@ -126,6 +126,11 @@ NETWORK:
 *
 
 ```
+
+You do need to be fully aware of standard browser caching.
+If the files in `CACHE` are in the network cache, they won't actually update,
+since the network cache will spit back the same file to the application cache.
+Therefore, it's recommended to add a hash to the filenames's, akin to rails or yeoman.
 
 
 ## Release History


### PR DESCRIPTION
The `?rel=324784983` querystrings are misleading, this is NOT a reliable method of cache busting. (So I removed them) This is something the developer needs to know about and since grunt-contrib-manifest is only concerned with generating the manifest. However, grunt-contrib-manifest could match rails md5 hash algorithm to hit the right files, same thing with yeoman, and there could be a setting to add the file hash before or after the filename (but always before the extension of course) There could also be a setting to add the file hash at the root like: `domain.com/hash/actual/path/to/file.js` this scheme may be easier to support for say, node.js
