### PR TITLE
reset directory after set base

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -14,9 +14,11 @@ module.exports = function (grunt) {
 
     var helpers = require("grunt-lib-contrib").init(grunt);
     var options = helpers.options(this, {verbose: true, timestamp:true});
+    var oldBase;
 
     // If we have a basePath, specify it
     if (this.data.options.basePath) {
+      oldBase = process.cwd();
       //var base = grunt.file.expandDirs(this.data.options.basePath);
       var base = this.data.options.basePath;
       grunt.file.setBase(base);
@@ -105,6 +107,10 @@ module.exports = function (grunt) {
     // Write file to disk
     grunt.verbose.writeln("\n" + (contents).yellow);
     grunt.file.write(destFile, contents);
+    
+    if (oldBase) {
+      grunt.file.setBase(oldBase);
+    }
     done();
   });
 


### PR DESCRIPTION
I know #3 says don't use setBase, but at least for now after using set base, reset the current directory.

Right now you can't run tasks after manifest as its its in a different directory.
