### PR TITLE
Expand to files only

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
 
       // if a basePath is set, expand using the original file pattern
       if (options.basePath) {
-        files = grunt.file.expand({cwd: options.basePath}, file.orig.src);
+        files = grunt.file.expand({cwd: options.basePath, filter: 'isFile'}, file.orig.src);
       } else {
         files = file.src;
       }


### PR DESCRIPTION
Currently a wildcard matches directories too, which fails later when trying to calculate a hash.
