### PR TITLE
Add options.absolutePaths.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,24 @@ module.exports = function(grunt) {
                     'folder_two/*.css'
                 ],
                 dest: 'tmp/manifest2.appcache'
-            }
+            },
+            master3: {
+                options: {
+                    basePath: 'test/fixtures',
+                    verbose: false,
+                    timestamp: false,
+                    absolutePaths: true,
+                    master: 'master1.html'
+                },
+                src: [
+                    '*.js',
+                    '*.css',
+                    'folder_one/*',
+                    'folder_two/*.js',
+                    'folder_two/*.css'
+                ],
+                dest: 'tmp/manifest3.appcache'
+            },
 		},
 
 		// Unit tests.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ Default: `undefined`
 
 Hashes master html files (used with `hash`). Paths must be relative to the 'basePath'. This is useful when there are multiple html pages using one cache manifest and you don't want to explicitly include those pages in the manifest.
 
+#### absolutePaths
+Type: `Boolean`
+Default: `false`
+
+Generate cache files with absolute paths, `/test.js` instead of `test.js`.
+
+
 ### Config Example
 
 ```js

--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -19,6 +19,14 @@ module.exports = function (grunt) {
 
     var path = require('path');
 
+    function encodePath(path) {
+        if (options.absolutePaths) {
+            return encodeURI(path.charAt(0) === '/' ? path : '/' + path);
+        } else {
+            return encodeURI(path);
+        }
+    }
+
     this.files.forEach(function (file) {
 
       var files;
@@ -75,7 +83,7 @@ module.exports = function (grunt) {
       // add files to explicit cache manually
       if (cacheFiles) {
         cacheFiles.forEach(function (item) {
-          contents += encodeURI(item) + '\n';
+          contents += encodePath(item) + '\n';
         });
       }
 
@@ -83,9 +91,9 @@ module.exports = function (grunt) {
       if (files) {
         files.forEach(function (item) {
           if (options.process) {
-            contents += encodeURI(options.process(item)) + '\n';
+            contents += encodePath(options.process(item)) + '\n';
           } else {
-            contents += encodeURI(item) + '\n';
+            contents += encodePath(item) + '\n';
           }
 
           // hash file contents
@@ -100,7 +108,7 @@ module.exports = function (grunt) {
       if (options.network) {
         contents += '\nNETWORK:\n';
         options.network.forEach(function (item) {
-          contents += encodeURI(item) + '\n';
+          contents += encodePath(item) + '\n';
         });
       } else {
         // If there's no network section, add a default '*' wildcard
@@ -112,7 +120,7 @@ module.exports = function (grunt) {
       if (options.fallback) {
         contents += '\nFALLBACK:\n';
         options.fallback.forEach(function (item) {
-          contents += encodeURI(item) + '\n';
+          contents += encodePath(item) + '\n';
         });
       }
 

--- a/test/expected/manifest3.appcache
+++ b/test/expected/manifest3.appcache
@@ -1,0 +1,12 @@
+CACHE MANIFEST
+
+CACHE:
+/test.js
+/test.css
+/folder_one/one.css
+/folder_one/one.js
+/folder_two/two.js
+/folder_two/two.css
+
+NETWORK:
+*

--- a/test/manifest_test.js
+++ b/test/manifest_test.js
@@ -4,7 +4,7 @@ var grunt = require('grunt');
 
 exports.manifest = {
   generate: function (test) {
-    test.expect(3);
+    test.expect(4);
 
     var actual = grunt.file.read('tmp/manifest.appcache');
     var expected = grunt.file.read('test/expected/manifest.appcache');
@@ -20,6 +20,11 @@ exports.manifest = {
     expected = grunt.file.read('test/expected/manifest2.appcache');
 
     test.equal(actual, expected, 'should generate a cache manifest (with master1.html & master2.html as masters).');
+
+    actual = grunt.file.read('tmp/manifest3.appcache');
+    expected = grunt.file.read('test/expected/manifest3.appcache');
+
+    test.equal(actual, expected, 'should generate a cache manifest (with absolute paths).');
 
     test.done();
   }


### PR DESCRIPTION
This fixes issues with single-page applications that use pushState.
The applications may serve up `index.html` for a URI with a long
path, such as `http://mytodoapp.com/items/4`

Generate cache files with absolute paths, `/test.js` instead of `test.js`.