### PR TITLE
Add support for external resources in the src array

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -18,13 +18,8 @@ module.exports = function (grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     var path = require('path');
-    var isExternal = /https?:/;
 
     this.files.forEach(function (file) {
-
-      var externalFiles = file.orig.src.filter(function(file) {
-          return isExternal.test(file);
-      });
 
       var files;
       var cacheFiles = options.cache;
@@ -81,13 +76,6 @@ module.exports = function (grunt) {
       if (cacheFiles) {
         cacheFiles.forEach(function (item) {
           contents += encodeURI(item) + '\n';
-        });
-      }
-
-      // add external files to explicit cache
-      if (externalFiles) {
-        externalFiles.forEach(function (item) {
-          contents += item + 't\n';
         });
       }
 

--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -18,8 +18,13 @@ module.exports = function (grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     var path = require('path');
+    var isExternal = /https?:/;
 
     this.files.forEach(function (file) {
+
+      var externalFiles = file.orig.src.filter(function(file) {
+          return isExternal.test(file);
+      });
 
       var files;
       var cacheFiles = options.cache;
@@ -76,6 +81,13 @@ module.exports = function (grunt) {
       if (cacheFiles) {
         cacheFiles.forEach(function (item) {
           contents += encodeURI(item) + '\n';
+        });
+      }
+
+      // add external files to explicit cache
+      if (externalFiles) {
+        externalFiles.forEach(function (item) {
+          contents += item + 't\n';
         });
       }
 

--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -18,8 +18,13 @@ module.exports = function (grunt) {
     grunt.verbose.writeflags(options, 'Options');
 
     var path = require('path');
+    var isExternal = /https?:/;
 
     this.files.forEach(function (file) {
+
+      var externalFiles = file.orig.src.filter(function(file) {
+          return isExternal.test(file);
+      });
 
       var files;
       var cacheFiles = options.cache;
@@ -95,6 +100,14 @@ module.exports = function (grunt) {
           }
         });
       }
+
+      // add external files to explicit cache
+      if (externalFiles) {
+        externalFiles.forEach(function (item) {
+          contents += item + '\n';
+        });
+      }
+
 
       // Network section
       if (options.network) {


### PR DESCRIPTION
It's my understanding that the appcache can also cache external resources, however when you add an external resource to the src array, e.g.

```
manifest : {
    generate : {
        src : [
            "http://fonts.googleapis.com/css?family=Black+Ops+One"
        ]
    }
}
```

it doesn't add the url to the explicit cache.  This pull requests fixes that by looking at the _file.orig.src_ and seeing which files are external.  It then adds the urls to the explicit cache after the local files have been processed.
