### PR TITLE
Allow spaces in the fallback section contents

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -116,7 +116,7 @@ module.exports = function (grunt) {
       if (options.fallback) {
         contents += '\nFALLBACK:\n';
         options.fallback.forEach(function (item) {
-          contents += encodeURI(item) + '\n';
+          contents += encodeURI(item).replace('%20', ' ') + '\n';
         });
       }
 


### PR DESCRIPTION
This allows for use of the `/ offline.html` pattern. Without this patch `/ offline.html` would be output to the manifest file as `/%20offline.html`
